### PR TITLE
Update API

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,26 +5,35 @@ import logo from './mlh-prep.png'
 function App() {
   const [error, setError] = useState(null);
   const [isLoaded, setIsLoaded] = useState(false);
-  const [city, setCity] = useState("New York City")
+  const [city, setCity] = useState("New York City");
   const [results, setResults] = useState(null);
 
   useEffect(() => {
-    fetch("https://api.openweathermap.org/data/2.5/weather?q=" + city + "&units=metric" + "&appid=" + process.env.REACT_APP_APIKEY)
+    fetch("http://api.openweathermap.org/geo/1.0/direct?q=" + city
+	+ "&limit=5&appid=" + process.env.REACT_APP_APIKEY)
       .then(res => res.json())
+      .then(geo => geo[0])
       .then(
-        (result) => {
-          if (result['cod'] !== 200) {
-            setIsLoaded(false)
-          } else {
-            setIsLoaded(true);
-            setResults(result);
-          }
-        },
-        (error) => {
-          setIsLoaded(true);
-          setError(error);
-        }
-      )
+	geo => {
+	  fetch("https://api.openweathermap.org/data/2.5/weather?lat=" +
+		geo['lat'] + "&lon=" + geo['lon'] + "&units=metric&appid=" + process.env.REACT_APP_APIKEY)
+	    .then(res => res.json())
+	    .then(
+              (result) => {
+		if (result['cod'] !== 200) {
+		  setIsLoaded(false)
+		} else {
+		  setIsLoaded(true);
+		  setResults(result);
+		}
+              },
+              (error) => {
+		setIsLoaded(true);
+		setError(error);
+              }
+	    )
+	}
+      );
   }, [city])
 
   if (error) {


### PR DESCRIPTION
Update from deprecated built-in geocoder API to using currently recommended geocoding API.

The [documentation for the Openweathermap current weather API](https://openweathermap.org/current) states:

_Please use [Geocoder API](https://openweathermap.org/api/geocoding-api) if you need automatic convert city names and zip-codes to geo coordinates and the other way around._

_Please note that [built-in geocoder](https://openweathermap.org/current#geocoding) has been deprecated. Although it is still available for use, bug fixing and updates are no longer available for this functionality._

Currently, the app uses the deprecated API. This PR updates the app to use the recommended geocoding API. 