### PR TITLE
Change title and fix errors

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>TravelPrep</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/components/climate/AirQuality.js
+++ b/src/components/climate/AirQuality.js
@@ -29,7 +29,7 @@ const AirQuality = ({ coordinates }) => {
     const fetchAirQuality = async () => {
       if (lon && lat) {
         const response = await fetch(
-          `http://api.openweathermap.org/data/2.5/air_pollution?lat=${lat}&lon=${lon}&appid=${process.env.REACT_APP_APIKEY}`
+          `https://api.openweathermap.org/data/2.5/air_pollution?lat=${lat}&lon=${lon}&appid=${process.env.REACT_APP_APIKEY}`
         );
 
         const result = await response.json();

--- a/src/components/forecast/Forecast.js
+++ b/src/components/forecast/Forecast.js
@@ -12,9 +12,6 @@ const Forecast = ({ city }) => {
   const [forecastView, setForecastView] = useState(null);
   const todayDate = new Date(Date.now());
 
-  //  const basename = process.env.REACT_APP_URL;
-  //  const uri = basename + '/api/proxy?api=forecast&q=' + city +
-  //              '&units=metric';
   const uri =
     'https://api.openweathermap.org/data/2.5/forecast?&q=' +
     city +
@@ -76,16 +73,15 @@ const Forecast = ({ city }) => {
    and return an array of arrays containing that same information
    grouped by day */
 function regroupForecastResults(forecastResultsArr) {
-  const firstDay = forecastResultsArr[0].date.getDate();
-  const regroupedByDay = [];
-
-  for (let i = firstDay; i - firstDay < 5; i++) {
-    const dayForecast = forecastResultsArr.filter(
-      (d) => d.date.getDate() === i
-    );
-    regroupedByDay.push(dayForecast);
-  }
-
+  const forecastMap = new Map();
+  forecastResultsArr.forEach((forecast) => {
+    const dateKey = forecast.date.toISOString().substring(0, 10); // Use ISO string to get date without time
+    if (!forecastMap.has(dateKey)) {
+      forecastMap.set(dateKey, []);
+    }
+    forecastMap.get(dateKey).push(forecast);
+  });
+  const regroupedByDay = Array.from(forecastMap.values());
   return regroupedByDay;
 }
 
@@ -113,6 +109,7 @@ function makeDay(dayForecast) {
     hours: hours,
     temp: { min: minTemp, max: maxTemp },
   };
+
   return day;
 }
 


### PR DESCRIPTION
Fixes #27 

Also fixes two errors:
- air quality data was making call to HTTP link, but needs to be HTTPS. Call to OpenWeatherMap was failing because of this.
- 5-day forecast stopped working because of a bug trying to access 5 consecutive days in a row. We were incrementing the day by 1, but came across an error when we hit the end of the month. For example, when accessing the data on April 28th, we have to account for the sequence of days to go from 28 – 29 – 30 – 1 – 2, rather than 28 - 29 - 30 - 31 - 32.